### PR TITLE
fix(actions): Create separate job for deployment

### DIFF
--- a/.github/workflows/build_deployment.yml
+++ b/.github/workflows/build_deployment.yml
@@ -4,7 +4,7 @@
 
 name: Build, Test and Deploy
 
-on: [push, pull_request]
+on: push
 
 jobs:
   build:

--- a/.github/workflows/build_deployment.yml
+++ b/.github/workflows/build_deployment.yml
@@ -1,30 +1,39 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# This workflow will do a clean install of node dependencies, build the source code, run tests and deploy (if pushing to main branch)
+# For more information see: - https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions 
+#                           - https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 
-name: Build and deployment to AWS lambda
+name: Build, Test and Deploy
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   build:
-
+    name: Build and test
     runs-on: ubuntu-latest
-
     steps:
     - name: Check out repository
       uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: Install dependencies
+    - name: Clean install service dependencies
+      run: npm ci
+
+  deploy:
+    name: Deploy
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Install serverless
       run: npm install -g serverless
-   # - run: npm run build --if-present
-   # - run: npm test
     - name: Configure serverless
       run: serverless config credentials --provider aws --key ${{ secrets.AWS_KEY }} --secret ${{ secrets.AWS_SECRET }}
     - name: Deploy Lambda functions


### PR DESCRIPTION
## Change Description

The action caused deployment of serverless app when creating a pull request. 

**Solution:** Create 2 separate jobs:

1. Build and Test: Runs on every push to any branch in the repo.
2. Deploy: Only runs when pushing to master and if `Build and Test` job finished successfully.

**PS:** I couldn't figure out how to share steps between 2 jobs so there is duplicate code for the `Node 12.x` setup 😞 . If you're not happy with this approach, we could create 1 job and just add an `if condition` on the step for `deployment`. But you would still be running these steps uselessly: 

```
 - name: Install serverless
    run: npm install -g serverless
 - name: Configure serverless
    run: serverless config credentials --provider aws --key ${{ secrets.AWS_KEY }} --secret ${{ secrets.AWS_SECRET }}```